### PR TITLE
Fixes typo in Discord Login

### DIFF
--- a/src/notifications/discord.ts
+++ b/src/notifications/discord.ts
@@ -139,4 +139,4 @@ limit 10;`
 });
 
 // Login to Discord with your client's token
-client.login(process.env.DICORD_TOKEN);
+client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
Not sure if the Discord code was meant to actually work right now, if not we can just close this and I'll have it fixed in the new version, otherwise this might help :) 

(Not sure if you fixed it by putting the typo'd ENV variable into Heroku)